### PR TITLE
(fix) Make plug-in loadable in mayapy by checking kLibraryApp mode

### DIFF
--- a/instanceAlongCurve.py
+++ b/instanceAlongCurve.py
@@ -1814,7 +1814,7 @@ class instanceAlongCurveLocatorManip(OpenMayaMPx.MPxManipContainer):
 def initializePlugin( mobject ):
     mplugin = OpenMayaMPx.MFnPlugin( mobject, "mmerchante", kPluginVersion )
     try:
-        if OpenMaya.MGlobal.mayaState() != OpenMaya.MGlobal.kBatch:
+        if (OpenMaya.MGlobal.mayaState() != OpenMaya.MGlobal.kBatch) and (OpenMaya.MGlobal.mayaState() != OpenMaya.MGlobal.kLibraryApp):
             
             # Register command
             mplugin.registerCommand( kPluginCmdName, instanceAlongCurveCommand.cmdCreator )
@@ -1841,7 +1841,7 @@ def uninitializePlugin( mobject ):
     try:
         mplugin.deregisterNode( kPluginNodeId )
 
-        if OpenMaya.MGlobal.mayaState() != OpenMaya.MGlobal.kBatch:
+        if (OpenMaya.MGlobal.mayaState() != OpenMaya.MGlobal.kBatch) and (OpenMaya.MGlobal.mayaState() != OpenMaya.MGlobal.kLibraryApp):
             mplugin.deregisterCommand( kPluginCmdName )
             mplugin.deregisterNode( kPluginNodeManipId )
     except:


### PR DESCRIPTION
Hi,

Thanks for a great plug-in!

The plug-in initialize and uninitialize are checking for kBatch mode but are not checking for kLibraryApp mode, making it not loadable in mayapy. This pull request should fix the issue.

I found another mayapy-related issue which I could not find a solution to. I will open an issue on this.